### PR TITLE
Fix go get and darwin support.

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -1,0 +1,9 @@
+package godaemon
+
+// Copyright (c) 2013 VividCortex, Inc. All rights reserved.
+// Please see the LICENSE file for applicable license terms.
+
+// A DaemonAttr describes the options that apply to daemonization
+type DaemonAttr struct {
+	CaptureOutput bool // whether to capture stdout/stderr
+}

--- a/daemon_darwin.go
+++ b/daemon_darwin.go
@@ -7,11 +7,6 @@ import (
 // Copyright (c) 2013 VividCortex, Inc. All rights reserved.
 // Please see the LICENSE file for applicable license terms.
 
-// A DaemonAttr describes the options that apply to daemonization
-type DaemonAttr struct {
-	CaptureOutput bool // whether to capture stdout/stderr
-}
-
 // Daemonize is a no-op on MacOSX Darwin.
 func Daemonize(child bool) {
 }

--- a/daemon_linux.go
+++ b/daemon_linux.go
@@ -19,11 +19,6 @@ import (
 // The name of the env var that indicates what stage of daemonization we're at.
 const stageVar = "__DAEMON_STAGE"
 
-// A DaemonAttr describes the options that apply to daemonization
-type DaemonAttr struct {
-	CaptureOutput bool // whether to capture stdout/stderr
-}
-
 /*
 MakeDaemon turns the process into a daemon. But given the lack of Go's
 support for fork(), MakeDaemon() is forced to run the process all over again,


### PR DESCRIPTION
It seems that d5a0140a6d3443678904ab30fc951193a25f8d4e broke the ability to `go get` this package. By importing "io" and returning nil, functionality doesn't change and `go get` works again. This snippet is from after I applied and pushed the attached patch:

```
[marpaia] ~ go get github.com/VividCortex/godaemon
# github.com/VividCortex/godaemon
go/src/github.com/VividCortex/godaemon/daemon_darwin.go:11: undefined: io
go/src/github.com/VividCortex/godaemon/daemon_darwin.go:12: missing return at end of function
[marpaia] ~ go get github.com/marpaia/godaemon
[marpaia] ~
```

Since I applied the patch on my own fork, the `go get` worked properly, etc.

---

Also, since `Daemonize` is only kept for backwards API compatibility and `godaemon.MakeDaemon(&godaemon.DaemonAttr{})` is the preferred way to create a daemon, `MakeDaemon` doesn't work on OS X because it was never added to `daemon_darwin.go`. I added it to `daemon_darwin.go` as a no-op, just like `MakeDaemon` so that at least code will compile.

---

Also, since `DaemonAttr` is needed in both `daemon_linux` and `daemon_darwin`, I moved it to a new file, `daemon.go` so that it is accessible by both files.
