### PR TITLE
NoChdir option

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -27,6 +27,7 @@ const (
 type DaemonAttr struct {
 	CaptureOutput bool        // whether to capture stdout/stderr
 	Files         []**os.File // files to keep open in the daemon
+	NoChdir       bool        // whether to chdir to /
 }
 
 /*
@@ -205,7 +206,9 @@ func MakeDaemon(attrs *DaemonAttr) (io.Reader, io.Reader, error) {
 		os.Exit(0)
 	}
 
-	os.Chdir("/")
+	if !attrs.NoChdir {
+		os.Chdir("/")
+	}
 	syscall.Umask(0)
 	resetEnv()
 


### PR DESCRIPTION
This pull request adds a new `DaemonAttr` option called `NoChdir` that stops godaemon from chdir'ing to / in stage 2.

I've added this functionality because a project I'm working on ([remote_syslog2](https://github.com/papertrail/remote_syslog2)) needs to both daemonize and accept relative paths on the command line. The easiest way to do that is to not `chdir` at all. I don't think there's any downside to this option, I may have missed something?
