### PR TITLE
Remove CGO dependency from daemon_darwin.go

### DIFF
--- a/daemon_darwin.go
+++ b/daemon_darwin.go
@@ -3,38 +3,13 @@ package godaemon
 // Copyright (c) 2013 VividCortex, Inc. All rights reserved.
 // Please see the LICENSE file for applicable license terms.
 
-//#include <mach-o/dyld.h>
-import "C"
-
 import (
-	"bytes"
-	"fmt"
-	"path/filepath"
-	"unsafe"
+	"os"
 )
 
 // GetExecutablePath returns the absolute path to the currently running
 // executable.  It is used internally by the godaemon package, and exported
 // publicly because it's useful outside of the package too.
 func GetExecutablePath() (string, error) {
-	PATH_MAX := 1024 // From <sys/syslimits.h>
-	exePath := make([]byte, PATH_MAX)
-	exeLen := C.uint32_t(len(exePath))
-
-	status, err := C._NSGetExecutablePath((*C.char)(unsafe.Pointer(&exePath[0])), &exeLen)
-
-	if err != nil {
-		return "", fmt.Errorf("_NSGetExecutablePath: %v", err)
-	}
-
-	// Not sure why this might happen with err being nil, but...
-	if status != 0 {
-		return "", fmt.Errorf("_NSGetExecutablePath returned %d", status)
-	}
-
-	// Convert from null-padded []byte to a clean string. (Can't simply cast!)
-	exePathStringLen := bytes.Index(exePath, []byte{0})
-	exePathString := string(exePath[:exePathStringLen])
-
-	return filepath.Clean(exePathString), nil
+	return os.Executable()
 }


### PR DESCRIPTION
This should fix the darwin on linux cross compilation issue.

From the golang docs around os.Executable:

```
Executable returns the path name for the executable that started the current process. There is no guarantee that the path is still pointing to the correct executable. If a symlink was used to start the process, depending on the operating system, the result might be the symlink or the path it pointed to. If a stable result is needed, path/filepath.EvalSymlinks might help.

Executable returns an absolute path unless an error occurred.
```


Fixes #31 