### PR TITLE
Module support for go 1.11 and above.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/VividCortex/godaemon
+
+go 1.11


### PR DESCRIPTION
Go 1.17 will be removing support for libraries that aren't modules, this migrates to module support for go 1.11 and above.